### PR TITLE
refactor(ui): Refactor ParaCard component and remove unused styles Switch from Shadow DOM to integrated UI; update ParaCard props, CSS summary

### DIFF
--- a/src/assets/ParaCard.css
+++ b/src/assets/ParaCard.css
@@ -1,0 +1,13 @@
+.para-card {
+  font-size: 0.8em;
+  margin-block: 0.5em;
+  padding-inline: clamp(4px, 0.5em, 1em);
+  line-height: clamp(1.5, 1.7, 2);
+  border-inline-start: 3px solid lightslategray;
+  border-radius: 3px;
+}
+
+.para-card-loading {
+  text-align: center;
+  font-style: italic;
+}

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -8,9 +8,9 @@
 
 @theme {
   --font-sans:
-    'HYKongShanKai', 'Inter Variable', 'Inter Fallback', system-ui, -apple-system,
-    BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif,
-    'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+    'Inter Variable', 'Inter Fallback', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
   --font-mono: ui-monospace, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
 }
 
@@ -29,14 +29,6 @@
 
 * {
   scrollbar-width: thin;
-}
-
-.bb {
-  border: 1px solid gray;
-}
-
-.bb2 {
-  border: 1px solid yellow;
 }
 
 /* Global transition animations */

--- a/src/assets/content-ui.css
+++ b/src/assets/content-ui.css
@@ -1,9 +1,0 @@
-@import './base.css';
-
-* {
-  font-size: clamp(14px, 0.82rem, 18px);
-}
-
-body {
-  background-color: transparent;
-}

--- a/src/components/ParaCard.vue
+++ b/src/components/ParaCard.vue
@@ -1,11 +1,7 @@
 <script setup lang="ts">
 import { CircleAlert } from 'lucide-vue-next';
-import { ref } from 'vue';
-import VueMarkdown from 'vue-markdown-render';
 
 import { HistoryData } from '@/agent/types';
-import { DISABLED_EXPLANATION } from '@/constant';
-import { createLogger } from '@/utils/logger';
 
 export interface ParaCardProps extends HistoryData {
   showContext?: boolean;
@@ -20,104 +16,19 @@ const props = withDefaults(defineProps<ParaCardProps>(), {
   translation: '',
   explanation: '',
 });
-
-const logger = createLogger('ParaCard');
-const showTab = ref(props.showContext ? 'context' : 'translation');
 </script>
 
 <template>
-  <div class="card card-border bg-base-100 rounded-[4px]">
-    <div v-if="props.error?.type === 'translate'" role="alert" class="card-body alert alert-error">
+  <div class="para-card">
+    <div v-if="props.error?.type === 'translate'" role="alert" class="para-card-alert">
       <CircleAlert />
       <span>{{ props.error.message }}</span>
     </div>
-    <div v-if="!props.translation" class="card-body mx-auto w-fit">
-      <span class="loading loading-spinner loading-sm"></span>
+    <div v-if="!props.translation" class="para-card-loading">
+      <span>Loading...</span>
     </div>
-    <div v-else class="card-body">
+    <div v-else class="para-card-content">
       {{ props.translation }}
     </div>
   </div>
-
-  <!-- <div class="card prose grid max-w-full rounded-md">
-
-    <div class="tabs tabs-sm tabs-box justify-end-safe">
-      <input
-        v-if="showContext"
-        type="radio"
-        name="my_tabs_1"
-        value="context"
-        v-model="showTab"
-        class="tab"
-        aria-label="Context"
-      />
-
-      <div class="tab-content">
-        <div v-if="!props.context">
-          <span class="loading loading-spinner loading-sm"></span>
-          <span class="text-base-content/70">Loading...</span>
-        </div>
-        <div v-else>
-          <ul class="grid grid-cols-1 gap-2">
-            <li v-for="(value, key) in props.context" :key="key" class="flex gap-2">
-              <span class="font-medium">{{ key }}:</span>
-              <span class="text-base-content/80">{{ value }}</span>
-            </li>
-          </ul>
-        </div>
-      </div>
-
-      <input
-        type="radio"
-        name="my_tabs_1"
-        value="translation"
-        v-model="showTab"
-        class="tab"
-        aria-label="Translation"
-        checked="true"
-      />
-      <div class="tab-content bg-base-100 border-base-300">
-        <div v-if="props.error?.type === 'translate'" role="alert" class="alert alert-error">
-          <CircleAlert />
-          <span>{{ props.error.message }}</span>
-        </div>
-        <div v-if="!props.translation">
-          <span class="loading loading-spinner loading-sm"></span>
-          <span class="text-base-content/70">Loading...</span>
-        </div>
-        <div v-else>
-          {{ props.translation }}
-        </div>
-      </div>
-
-      <input
-        v-if="!DISABLED_EXPLANATION"
-        type="radio"
-        name="my_tabs_1"
-        value="explanation"
-        v-model="showTab"
-        class="tab"
-        aria-label="Explanation"
-      />
-      <div class="tab-content">
-        <div v-if="props.error?.type === 'explain'" role="alert" class="alert alert-error">
-          <CircleAlert />
-          <span>{{ props.error.message }}</span>
-        </div>
-        <div v-else-if="!props.explanation">
-          <span class="loading loading-spinner loading-sm"></span>
-          <span class="text-base-content/70">Loading...</span>
-        </div>
-        <div v-else class="max-h-96 overflow-y-auto">
-          <VueMarkdown :source="props.explanation" />
-        </div>
-      </div>
-    </div>
-  </div> -->
 </template>
-<style scoped>
-.card-body {
-  padding: clamp(8px, 0.25rem + 0.94vw, 1.5rem);
-  line-height: clamp(1.5, 1.7, 2);
-}
-</style>

--- a/src/entrypoints/content/index.ts
+++ b/src/entrypoints/content/index.ts
@@ -1,6 +1,6 @@
 import { defineContentScript } from '#imports';
 
-import '@/assets/content-ui.css';
+// import '@/assets/content-ui.css';
 
 import { setupEventListeners } from '@/entrypoints/content/event-handler';
 import { createLogger } from '@/utils/logger';


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Content UI now integrates directly into pages (no Shadow DOM), improving visual consistency and reducing styling isolation.
  * Styles are injected and cleaned up with the widget for a tidier experience.

* **Style**
  * New compact “para card” styling with subtle border, padding, and tighter line-height.
  * Added centered, italic loading state for cards.
  * Updated default font stack for improved fallbacks; removed a decorative font.
  * Removed legacy global content styles to avoid unintended page-wide overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->